### PR TITLE
fix: disable gamescope capSysNice to unblock Steam/bubblewrap

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780148589,
-        "narHash": "sha256-AoajCuPZMpVyUhSjm23QmIQNZMSyiEpA8awaJayrtTE=",
+        "lastModified": 1780436840,
+        "narHash": "sha256-D5Ik+wvjyWSkV8tSLDzuO821riPBm7p8+2a8HttXdjk=",
         "owner": "MarkusBitterman",
         "repo": "DOORwayDE",
-        "rev": "9146bbf9c2e041db86002e7e3071d797b8b6f27d",
+        "rev": "eefc3a46adc76895a8916772fbff76222229a63e",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780099287,
-        "narHash": "sha256-efIPwVGtIWIjWcznhaop6XN6HxnOL8800hF6CBNvlqQ=",
+        "lastModified": 1780593650,
+        "narHash": "sha256-CHo7k65YTL3HY+WQVedDTupji+LMgNlKCdrtRHZFAK4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d8127d308c3fb9664f7e643eec944be74ebb37d",
+        "rev": "447fd9ff62501dae7206dfe180ee89f8de27b7d5",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777944972,
-        "narHash": "sha256-VfGRo1qTBKOe3s2gOv8LSoA6Fk19PvBlwQ1ECN0Evn8=",
+        "lastModified": 1780547341,
+        "narHash": "sha256-Gq8KNx5A7hBB3uGJaj6eQfLDIz5YdLu92gqBcvHvoUo=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c591bf665727040c6cc5cb409079acb22dcce33c",
+        "rev": "9ed65852b6257fbeae4355bc24ecfea307ca759a",
         "type": "github"
       },
       "original": {

--- a/hosts/2600AD/configuration.nix
+++ b/hosts/2600AD/configuration.nix
@@ -6,7 +6,6 @@
 
 {
   config,
-  lib,
   pkgs,
   ...
 }:
@@ -246,6 +245,9 @@
     "/share/xdg-desktop-portal"
   ];
 
+  # Android full SDK (needed by Unity and build tools):
+  nixpkgs.config.android_sdk.accept_license = true;
+
   environment.systemPackages = with pkgs; [
     # System essentials
     nano
@@ -259,6 +261,24 @@
     # System tools
     sshfs
 
+    # Android tools, SDK, NDK
+    android-tools
+    (androidenv.composeAndroidPackages {
+      platformVersions = [
+        "34"
+        "33"
+      ];
+      abiVersions = [
+        "x86_64"
+        "arm64-v8a"
+      ];
+      buildToolsVersions = [ "34.0.0" ];
+      includeNDK = true;
+    }).androidsdk
+
+    # Unity development
+    dotnet-sdk_8
+    mono
     # Note: Steam provided by programs.steam.enable (includes steam-run)
   ];
 
@@ -287,16 +307,6 @@
 
   security.polkit.enable = true;
   security.apparmor.enable = true;
-  # programs.steam auto-creates a setuid bwrap wrapper when gamescopeSession.enable
-  # && gamescope.capSysNice are both true. Bubblewrap 0.11.2 is compiled
-  # --disable-setuid; the wrapper causes an immediate "setuid use of bubblewrap
-  # is not supported in this build" crash. Unprivileged user namespaces suffice.
-  security.wrappers.bwrap = lib.mkForce {
-    owner = "root";
-    group = "root";
-    source = "${pkgs.bubblewrap}/bin/bwrap";
-    setuid = false;
-  };
 
   # ════════════════
   # PROGRAMS
@@ -396,7 +406,7 @@
     };
     gamescope = {
       enable = true;
-      capSysNice = true;
+      capSysNice = false;
     };
     steam = {
       enable = true;

--- a/hosts/HALLpass.space/home/matt.nix
+++ b/hosts/HALLpass.space/home/matt.nix
@@ -19,7 +19,7 @@
 { osConfig, pkgs, ... }:
 
 {
-  home.stateVersion = "25.11";
+  home.stateVersion = "26.05";
 
   # Minimal operator toolset for a 25GB VPS.
   home.packages = with pkgs; [


### PR DESCRIPTION
## Summary

- Set `programs.gamescope.capSysNice = false` on 2600AD — this is the single flag that caused `nixos/modules/programs/steam.nix` to auto-create a setuid bwrap wrapper and hardcode `/run/wrappers/bin/bwrap` into Steam's FHS launch scripts. Bubblewrap 0.11.2 (compiled without `-Drequire_userns=true`) refuses to run in any privileged context, crashing with `bwrap: setuid use of bubblewrap is not supported in this build`.
- Removes the previous attempted fix (`lib.mkForce { setuid = false; }` + `lib` in module args) which didn't fully resolve the issue — `CAP_SYS_NICE` capability inheritance from gamescope still triggered bwrap's guard in the gamescope Steam session.
- Adds Android SDK / Unity dev tooling to 2600AD (`android-tools`, `androidenv`, `dotnet-sdk_8`, `mono`).
- Bumps `HALLpass.space` `home.stateVersion` to `26.05`.
- Updates all flake inputs (`nixpkgs`, `home-manager`, `sops-nix`, `doorwayde`).

## Test plan

- [ ] `ls /run/wrappers/bin/` — `bwrap` should not appear
- [ ] `steam` from terminal launches without bwrap error
- [ ] Gamescope Steam session in regreet does not drop back to greeter

🤖 Generated with [Claude Code](https://claude.com/claude-code)